### PR TITLE
Adds a builder pattern to achieve thread safety

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -19,12 +19,14 @@ Import the Email and EmailParser classes.
 ```java
 import com.edlio.emailreplyparser.Email;
 import com.edlio.emailreplyparser.EmailParser;
+import com.edlio.emailreplyparser.EmailParserBuilder;
 ```
 
-Instantiate an `EmailParser` object and parse your email:
+Instantiate an `EmailParserBuilder` object and create an immutable thread safe parser:
 
 ``` java
-EmailParser parser = new EmailParser();
+EmailParserBuilder parserBuilder = new EmailParserBuilder();
+EmailParser parser = parserBuilder.build();
 Email email = parser.parse(emailString);
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<groupId>com.edlio.emailreplyparser</groupId>
 	<artifactId>EmailReplyParser</artifactId>
 	<packaging>jar</packaging>
-	<version>1.1</version>
+	<version>2.0</version>
 	<name>EmailReplyParser</name>
 	<url>https://github.com/edlio/EmailReplyParser</url>
 	<dependencies>

--- a/src/main/java/com/edlio/emailreplyparser/Email.java
+++ b/src/main/java/com/edlio/emailreplyparser/Email.java
@@ -1,37 +1,34 @@
 package com.edlio.emailreplyparser;
 
-import java.util.ArrayList;
+import java.util.LinkedList;
 import java.util.List;
-
-import org.apache.commons.lang3.StringUtils;
+import java.util.stream.Collectors;
 
 public class Email {
-	private List<Fragment> fragments = new ArrayList<Fragment>();
-	
+	private List<Fragment> fragments;
+
 	public Email(List<Fragment> fragments) {
-		this.fragments = fragments;
+		this.fragments = new LinkedList<>(fragments);
 	}
-	
+
 	public List<Fragment> getFragments() {
 		return fragments;
 	}
-	
+
 	public String getVisibleText() {
-		List<String> visibleFragments = new ArrayList<String>();
-		for (Fragment fragment : fragments) {
-			if (!fragment.isHidden())
-				visibleFragments.add(fragment.getContent());
-		}
-		return StringUtils.stripEnd(StringUtils.join(visibleFragments,"\n"), null);
+		return fragments.stream()
+				.filter(fragment -> !fragment.isHidden())
+				.map(Fragment::getContent)
+				.collect(Collectors.joining("\n"))
+				.stripTrailing();
 	}
-	
+
 	public String getHiddenText() {
-		List<String> hiddenFragments = new ArrayList<String>();
-		for (Fragment fragment : fragments) {
-			if (fragment.isHidden())
-				hiddenFragments.add(fragment.getContent());
-		}
-		return StringUtils.stripEnd(StringUtils.join(hiddenFragments,"\n"), null);
+		return fragments.stream()
+				.filter(Fragment::isHidden)
+				.map(Fragment::getContent)
+				.collect(Collectors.joining("\n"))
+				.stripTrailing();
 	}
-	
+
 }

--- a/src/main/java/com/edlio/emailreplyparser/EmailParser.java
+++ b/src/main/java/com/edlio/emailreplyparser/EmailParser.java
@@ -1,8 +1,10 @@
 package com.edlio.emailreplyparser;
 
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.regex.Pattern;
 
@@ -12,65 +14,96 @@ import org.apache.commons.lang3.StringUtils;
 
 
 public class EmailParser {
-	
-	static final Pattern SIG_PATTERN = Pattern.compile( "((^Sent from my (\\s*\\w+){1,3}$)|(^-\\w|^\\s?__|^\\s?--|^\u2013|^\u2014))", Pattern.DOTALL);
-	static final Pattern QUOTE_PATTERN = Pattern.compile("(^>+)", Pattern.DOTALL);
-	private static List<Pattern> compiledQuoteHeaderPatterns;
-	
-	private List<String> quoteHeadersRegex = new ArrayList<String>();
-	private List<FragmentDTO> fragments = new ArrayList<FragmentDTO>();
-	private int maxParagraphLines;
-	private int maxNumCharsEachLine;
-	
-	
-	/**
-	 * Initialize EmailParser.
-	 */
-	public EmailParser() {
-		compiledQuoteHeaderPatterns = new ArrayList<Pattern>();
-		quoteHeadersRegex.add("^(On\\s(.{1,500})wrote:)");
-		quoteHeadersRegex.add("From:[^\\n]+\\n?([^\\n]+\\n?){0,2}To:[^\\n]+\\n?([^\\n]+\\n?){0,2}Subject:[^\\n]+");
-		quoteHeadersRegex.add("To:[^\\n]+\\n?([^\\n]+\\n?){0,2}From:[^\\n]+\\n?([^\\n]+\\n?){0,2}Subject:[^\\n]+");
-		maxParagraphLines = 6;
-		maxNumCharsEachLine = 200;
+
+	private static final Pattern SIG_PATTERN = Pattern.compile( "((^Sent from my (\\s*\\w+){1,3}$)|(^-\\w|^\\s?__|^\\s?--|^\u2013|^\u2014))", Pattern.DOTALL);
+	private static final Pattern QUOTE_PATTERN = Pattern.compile("(^>+)", Pattern.DOTALL);
+	private static final List<Pattern> DEFAULT_COMPILED_QUOTE_HEADER_PATERNS = List.of(
+			Pattern.compile("^(On\\s(.{1,500})wrote:)", Pattern.MULTILINE | Pattern.DOTALL),
+			Pattern.compile("From:[^\\n]+\\n?([^\\n]+\\n?){0,2}To:[^\\n]+\\n?([^\\n]+\\n?){0,2}Subject:[^\\n]+", Pattern.MULTILINE | Pattern.DOTALL),
+			Pattern.compile("To:[^\\n]+\\n?([^\\n]+\\n?){0,2}From:[^\\n]+\\n?([^\\n]+\\n?){0,2}Subject:[^\\n]+", Pattern.MULTILINE | Pattern.DOTALL)
+			);
+	private static final int DEFAULT_maxParagraphLines = 6;
+	private static final int DEFAULT_maxNumCharsEachLine = 200;
+
+	public static class EmailParserBuilder{
+
+		private List<String> quoteHeadersRegex = new ArrayList<>();
+		private int maxParagraphLines = DEFAULT_maxParagraphLines;
+		private int maxNumCharsEachLine = DEFAULT_maxNumCharsEachLine;
+
+		public EmailParserBuilder withQuoteHeadersRegex(String regex){
+			quoteHeadersRegex.add(regex);
+			return this;
+		}
+
+		public EmailParserBuilder withMaxParagraphLines(int maxParagraphLines){
+			this.maxNumCharsEachLine = maxParagraphLines;
+			return this;
+		}
+
+		public EmailParserBuilder withMaxNumCharsEachLine(int maxNumCharsEachLine){
+			this.maxNumCharsEachLine = maxNumCharsEachLine;
+			return this;
+		}
+
+		public EmailParser build(){
+			List<Pattern> compiledQuoteHeaderPatterns = new ArrayList<>(DEFAULT_COMPILED_QUOTE_HEADER_PATERNS);
+			quoteHeadersRegex.stream()
+					.map(regex -> Pattern.compile(regex, Pattern.MULTILINE | Pattern.DOTALL))
+					.forEach(compiledQuoteHeaderPatterns::add);
+			return new EmailParser(compiledQuoteHeaderPatterns, maxParagraphLines, maxNumCharsEachLine);
+		}
+
+	}
+
+	private final List<Pattern> compiledQuoteHeaderPatterns;
+	private final int maxParagraphLines;
+	private final int maxNumCharsEachLine;
+
+	private List<FragmentDTO> fragments;
+
+
+	private EmailParser(List<Pattern> compiledQuoteHeaderPatterns, int maxParagraphLines, int maxNumCharsEachLine){
+		this.compiledQuoteHeaderPatterns = compiledQuoteHeaderPatterns;
+		this.maxParagraphLines = maxParagraphLines;
+		this.maxNumCharsEachLine = maxNumCharsEachLine;
 	}
 
 	/**
-	 * Splits the given email text into a list of {@link Fragment} and returns the {@link Email} object. 
-	 * 
+	 * Splits the given email text into a list of {@link Fragment} and returns the {@link Email} object.
+	 *
 	 * @param emailText
 	 * @return
 	 */
 	public Email parse(String emailText) {
-		fragments = new ArrayList<FragmentDTO>();
-		compileQuoteHeaderRegexes();
-		
+		fragments = new LinkedList<>();
+
 		// Normalize line endings
 		emailText = emailText.replace("\r\n", "\n");
-		
+
 		FragmentDTO fragment = null;
-		
+
 		// Split body to multiple lines.
 		String[] lines = new StringBuilder(emailText).toString().split("\n");
 		/* Reverse the array.
-		 * 
-		 * Reversing the array makes us to parse from the bottom to the top.  
+		 *
+		 * Reversing the array makes us to parse from the bottom to the top.
 		 * This way we can check for quote headers lines above quoted blocks
 		 */
 		ArrayUtils.reverse(lines);
-		
+
 		/* Paragraph for multi-line quote headers.
 		 * Some clients break up the quote headers into multiple lines.
-	         */
-		List<String> paragraph = new ArrayList<String>();
-		
+		 */
+		List<String> paragraph = new LinkedList<>();
+
 		// Scans the given email line by line and figures out which fragment it belong to.
 		for (String line : lines){
-			// Strip new line at the end of the string 
+			// Strip new line at the end of the string
 			line = StringUtils.stripEnd(line, "\n");
 			// Strip empty spaces at the end of the string
 			line = StringUtils.stripEnd(line, null);
-			
+
 			/* If the fragment is not null and we hit the empty line,
 			 * we get the last line from the fragment and check if the last line is either
 			 * signature and quote headers.
@@ -79,69 +112,53 @@ public class EmailParser {
 			 */
 			if (fragment != null && line.isEmpty()) {
 				String last = fragment.lines.get(fragment.lines.size()-1);
-				
+
 				if (isSignature(last)) {
 					fragment.isSignature = true;
 					addFragment(fragment);
-					
+
 					fragment = null;
-				} 
+				}
 				else if (isQuoteHeader(paragraph)) {
 					fragment.isQuoted = true;
 					addFragment(fragment);
-					
+
 					fragment = null;
 				}
 				paragraph.clear();
 			}
-			
+
 			// Check if the line is a quoted line.
 			boolean isQuoted = isQuote(line);
-			
+
 			/*
 			 * If fragment is empty or if the line does not matches the current fragment,
 			 * create new fragment.
 			 */
 			if (fragment == null || !isFragmentLine(fragment, line, isQuoted)) {
-				if (fragment != null)
+				if (fragment != null){
 					addFragment(fragment);
-				
+				}
+
 				fragment = new FragmentDTO();
 				fragment.isQuoted = isQuoted;
-				fragment.lines = new ArrayList<String>();
+				fragment.lines = new LinkedList<>();
 			}
-			
+
 			// Add line to fragment and paragraph
-			fragment.lines.add(line);	
+			fragment.lines.add(line);
 			if (!line.isEmpty()) {
 				paragraph.add(line);
 			}
 		}
-		
-		if (fragment != null)
+
+		if (fragment != null){
 			addFragment(fragment);
-		
+		}
+
 		return createEmail(fragments);
 	}
-	
-	/**
-	 * Returns existing quote headers regular expressions.
-	 * 
-	 * @return
-	 */
-	public List<String> getQuoteHeadersRegex() {
-		return this.quoteHeadersRegex;
-	}
-	
-	/**
-	 * Sets quote headers regular expressions.
-	 * 
-	 * @param newRegex
-	 */
-	public void setQuoteHeadersRegex(List<String> newRegex) {
-		this.quoteHeadersRegex = newRegex;
-	}
-	
+
 	/**
 	 * Gets max number of lines allowed for each paragraph when checking quote headers.
 	 * @return
@@ -149,40 +166,23 @@ public class EmailParser {
 	public int getMaxParagraphLines() {
 		return this.maxParagraphLines;
 	}
-	
-	/**
-	 * Sets max number of lines allowed for each paragraph when checking quote headers.
-	 * 
-	 * @param maxParagraphLines
-	 */
-	public void setMaxParagraphLines(int maxParagraphLines) {
-		this.maxParagraphLines = maxParagraphLines;
-	}
-	
+
 	/**
 	 * Gets max number of characters allowed for each line when checking quote headers.
-	 * 
+	 *
 	 * @return
 	 */
 	public int getMaxNumCharsEachLine() {
 		return maxNumCharsEachLine;
 	}
-	
-	/**
-	 * Sets max number of characters allowed for each line when checking quote headers.
-	 * @param maxNumCharsEachLine
-	 */
-	public void setMaxNumCharsEachLine(int maxNumCharsEachLine) {
-		this.maxNumCharsEachLine = maxNumCharsEachLine;
-	}
-	
+
 	/**
 	 * Creates {@link Email} object from List of fragments.
 	 * @param fragmentDTOs
 	 * @return
 	 */
 	protected Email createEmail(List<FragmentDTO> fragmentDTOs) {
-		List <Fragment> fs = new ArrayList<Fragment>();
+		List <Fragment> fs = new LinkedList<>();
 		Collections.reverse(fragmentDTOs);
 		for (FragmentDTO f : fragmentDTOs) {
 			Collections.reverse(f.lines);
@@ -192,17 +192,7 @@ public class EmailParser {
 		}
 		return new Email(fs);
 	}
-	
-	/**
-	 * Compile all the quote headers regular expressions before the parsing.
-	 * 
-	 */
-	private void compileQuoteHeaderRegexes() {
-		for (String regex : quoteHeadersRegex) {
-			compiledQuoteHeaderPatterns.add(Pattern.compile(regex, Pattern.MULTILINE | Pattern.DOTALL));
-		}
-	}
-	
+
 	/**
 	 * Check if the line is a signature.
 	 * @param line
@@ -212,7 +202,7 @@ public class EmailParser {
 		boolean find = SIG_PATTERN.matcher(line).find();
 		return find;
 	}
-	
+
 	/**
 	 * Checks if the line is quoted line.
 	 * @param line
@@ -221,21 +211,21 @@ public class EmailParser {
 	private boolean isQuote(String line) {
 		return QUOTE_PATTERN.matcher(line).find();
 	}
-	
+
 	/**
-	 * Checks if lines in the fragment are empty. 
+	 * Checks if lines in the fragment are empty.
 	 * @param fragment
 	 * @return
 	 */
 	private boolean isEmpty(FragmentDTO fragment) {
 		return StringUtils.join(fragment.lines,"").isEmpty();
 	}
-	
+
 	/**
-	 * If the line matches the current fragment, return true.  
-	 * Note that a common reply header also counts as part of the quoted Fragment, 
+	 * If the line matches the current fragment, return true.
+	 * Note that a common reply header also counts as part of the quoted Fragment,
 	 * even though it doesn't start with `>`.
-	 * 
+	 *
 	 * @param fragment
 	 * @param line
 	 * @param isQuoted
@@ -244,32 +234,35 @@ public class EmailParser {
 	private boolean isFragmentLine(FragmentDTO fragment, String line, boolean isQuoted) {
 		return fragment.isQuoted == isQuoted || (fragment.isQuoted && (isQuoteHeader(Arrays.asList(line)) || line.isEmpty()));
 	}
-	
+
 	/**
 	 * Add fragment to fragments list.
 	 * @param fragment
 	 */
 	private void addFragment(FragmentDTO fragment) {
-		if (fragment.isQuoted || fragment.isSignature || isEmpty(fragment)) 
+		if (fragment.isQuoted || fragment.isSignature || isEmpty(fragment)){
 			fragment.isHidden = true;
-		
+		}
+
 		fragments.add(fragment);
 	}
-	
+
 	/**
 	 * Checks if the given multiple-lines paragraph has one of the quote headers.
-	 * Returns false if it doesn't contain any of the quote headers, 
+	 * Returns false if it doesn't contain any of the quote headers,
 	 * if paragraph lines are greater than maxParagraphLines, or line has more than maxNumberCharsEachLine characters.
-	 *   
+	 *
 	 * @param paragraph
 	 * @return
 	 */
 	private boolean isQuoteHeader(List<String> paragraph) {
-		if (paragraph.size() > maxParagraphLines)
+		if (paragraph.size() > maxParagraphLines){
 			return false;
+		}
 		for (String line : paragraph) {
-			if (line.length() > maxNumCharsEachLine)
+			if (line.length() > maxNumCharsEachLine){
 				return false;
+			}
 		}
 		Collections.reverse(paragraph);
 		String content = new StringBuilder(StringUtils.join(paragraph,"\n")).toString();
@@ -278,8 +271,8 @@ public class EmailParser {
 				return true;
 			}
 		}
-		
+
 		return false;
 
-	}	
+	}
 }

--- a/src/main/java/com/edlio/emailreplyparser/EmailReplyParser.java
+++ b/src/main/java/com/edlio/emailreplyparser/EmailReplyParser.java
@@ -1,15 +1,18 @@
 package com.edlio.emailreplyparser;
 
+import com.edlio.emailreplyparser.EmailParser.EmailParserBuilder;
+
 public class EmailReplyParser {
 
 	public static Email read(String emailText) {
-		if (emailText == null)
+		if (emailText == null){
 			emailText = "";
+		}
 
-		EmailParser parser = new EmailParser();
+		EmailParser parser = new EmailParserBuilder().build();
 		return parser.parse(emailText);
 	}
-	
+
 	public static String parseReply(String emailText) {
 		return read(emailText).getVisibleText();
 	}

--- a/src/test/java/com/edlio/emailreplyparser/EmailParserTest.java
+++ b/src/test/java/com/edlio/emailreplyparser/EmailParserTest.java
@@ -12,13 +12,15 @@ import java.util.regex.Pattern;
 import org.apache.commons.lang3.StringUtils;
 import org.junit.Test;
 
+import com.edlio.emailreplyparser.EmailParser.EmailParserBuilder;
+
 public class EmailParserTest {
 
 	@Test
 	public void testReadsSimpleBody() {
-		Email email = new EmailParser().parse(FixtureGetter.getFixture("email_1.txt"));
+		Email email = new EmailParserBuilder().build().parse(FixtureGetter.getFixture("email_1.txt"));
 		List<Fragment> fragments = email.getFragments();
-		
+
 		assertEquals(3, fragments.size());
 		assertEquals("Hi folks\n\nWhat is the best way to clear a Riak bucket of all key, values after\nrunning a test?\nI am currently using the Java HTTP API.\n", fragments.get(0).getContent());
 		for(Fragment f : fragments) {
@@ -27,311 +29,314 @@ public class EmailParserTest {
 		assertFalse(fragments.get(0).isSignature());
 		assertTrue(fragments.get(1).isSignature());
 		assertTrue(fragments.get(2).isSignature());
-		
+
 		assertFalse(fragments.get(0).isHidden());
 		assertTrue(fragments.get(1).isHidden());
 		assertTrue(fragments.get(2).isHidden());
-		
+
 		assertEquals("-Abhishek Kona\n\n", fragments.get(1).getContent());
 	}
 
 	@Test
 	public void testReadsTopPost() {
-		Email email = new EmailParser().parse(FixtureGetter.getFixture("email_3.txt"));
+		Email email = new EmailParserBuilder().build().parse(FixtureGetter.getFixture("email_3.txt"));
 		List<Fragment> fragments = email.getFragments();
-		
+
 		assertEquals(5, fragments.size());
-		
+
 		assertFalse(fragments.get(0).isQuoted());
 		assertFalse(fragments.get(1).isQuoted());
 		assertTrue(fragments.get(2).isQuoted());
 		assertFalse(fragments.get(3).isQuoted());
 		assertFalse(fragments.get(4).isQuoted());
-		
+
 		assertFalse(fragments.get(0).isSignature());
 		assertTrue(fragments.get(1).isSignature());
 		assertFalse(fragments.get(2).isSignature());
 		assertFalse(fragments.get(3).isSignature());
 		assertTrue(fragments.get(4).isSignature());
-		
+
 		assertFalse(fragments.get(0).isHidden());
 		assertTrue(fragments.get(1).isHidden());
 		assertTrue(fragments.get(2).isHidden());
 		assertTrue(fragments.get(3).isHidden());
 		assertTrue(fragments.get(4).isHidden());
-		
+
 		Pattern pattern = Pattern.compile("Oh thanks.\n\nHavin");
 		Matcher matcher = pattern.matcher(fragments.get(0).getContent());
 		assertTrue(matcher.find());
-		
+
 		pattern = Pattern.compile("^-A");
 		matcher = pattern.matcher(fragments.get(1).getContent());
 		assertTrue(matcher.find());
-		
+
 		pattern = Pattern.compile("On");
 		matcher = pattern.matcher(fragments.get(2).getContent());
 		assertTrue(matcher.find());
-		
+
 		pattern = Pattern.compile("^_");
 		matcher = pattern.matcher(fragments.get(4).getContent());
 		assertTrue(matcher.find());
 	}
-	
+
 	@Test
 	public void testReadsBottomPost() {
-		Email email = new EmailParser().parse(FixtureGetter.getFixture("email_2.txt"));
+		Email email = new EmailParserBuilder().build().parse(FixtureGetter.getFixture("email_2.txt"));
 		List<Fragment> fragments = email.getFragments();
-		
+
 		assertEquals(6, fragments.size());
-		
+
 		assertEquals("Hi,", fragments.get(0).getContent());
-		
+
 		Pattern pattern = Pattern.compile("You can list");
 		Matcher matcher = pattern.matcher(fragments.get(2).getContent());
 		assertTrue(matcher.find());
-		
+
 		pattern = Pattern.compile("On");
 		matcher = pattern.matcher(fragments.get(1).getContent());
 		assertTrue(matcher.find());
-		
+
 		pattern = Pattern.compile(">");
 		matcher = pattern.matcher(fragments.get(3).getContent());
 		assertTrue(matcher.find());
-		
+
 		pattern = Pattern.compile("^_");
 		matcher = pattern.matcher(fragments.get(5).getContent());
 		assertTrue(matcher.find());
 	}
-	
+
 	@Test
 	public void testRecognizesDateStringAboveQuote() {
-		Email email = new EmailParser().parse(FixtureGetter.getFixture("email_4.txt"));
+		Email email = new EmailParserBuilder().build().parse(FixtureGetter.getFixture("email_4.txt"));
 		List<Fragment> fragments = email.getFragments();
-		
+
 		Pattern pattern = Pattern.compile("Awesome");
 		Matcher matcher = pattern.matcher(fragments.get(0).getContent());
 		assertTrue(matcher.find());
-		
+
 		pattern = Pattern.compile("On");
 		matcher = pattern.matcher(fragments.get(1).getContent());
 		assertTrue(matcher.find());
-		
+
 		pattern = Pattern.compile("Loader");
 		matcher = pattern.matcher(fragments.get(1).getContent());
 		assertTrue(matcher.find());
-		
+
 	}
-	
+
 	@Test
 	public void testDoesNotModifyInputString() {
 		String input = "The Quick Brown Fox Jumps Over The Lazy Dog";
-		Email email = new EmailParser().parse(input);
+		Email email = new EmailParserBuilder().build().parse(input);
 		List<Fragment> fragments = email.getFragments();
-		
+
 		assertEquals("The Quick Brown Fox Jumps Over The Lazy Dog", fragments.get(0).getContent());
-		
+
 	}
-	
+
 	@Test
 	public void testComplexBodyWithOnlyOneFragment() {
-		Email email = new EmailParser().parse(FixtureGetter.getFixture("email_5.txt"));
+		Email email = new EmailParserBuilder().build().parse(FixtureGetter.getFixture("email_5.txt"));
 		List<Fragment> fragments = email.getFragments();
-		
+
 		assertEquals(1, fragments.size());
 	}
-	
+
 	@Test
 	public void testDealsWithMultilineReplyHeaders() {
-		Email email = new EmailParser().parse(FixtureGetter.getFixture("email_6.txt"));
+		Email email = new EmailParserBuilder().build().parse(FixtureGetter.getFixture("email_6.txt"));
 		List<Fragment> fragments = email.getFragments();
-		
+
 		Pattern pattern = Pattern.compile("I get");
 		Matcher matcher = pattern.matcher(fragments.get(0).getContent());
 		assertTrue(matcher.find());
-		
+
 		pattern = Pattern.compile("On");
 		matcher = pattern.matcher(fragments.get(1).getContent());
 		assertTrue(matcher.find());
-		
+
 		pattern = Pattern.compile("Was this");
 		matcher = pattern.matcher(fragments.get(2).getContent());
 		assertTrue(matcher.find());
 	}
-	
+
 	@Test
 	public void testGetVisibleTextReturnsOnlyVisibleFragments() {
-		Email email = new EmailParser().parse(FixtureGetter.getFixture("email_2_1.txt"));
+		Email email = new EmailParserBuilder().build().parse(FixtureGetter.getFixture("email_2_1.txt"));
 		List<Fragment> fragments = email.getFragments();
-		
-		List<String> visibleFragments = new ArrayList<String>();
+
+		List<String> visibleFragments = new ArrayList<>();
 		for (Fragment fragment : fragments) {
-			if (!fragment.isHidden())
+			if (!fragment.isHidden()){
 				visibleFragments.add(fragment.getContent());
+			}
 		}
 		assertEquals(StringUtils.stripEnd(StringUtils.join(visibleFragments,"\n"), null), email.getVisibleText());
 	}
-	
+
 	@Test
 	public void testReadsEmailWithCorrectSignature() {
-		Email email = new EmailParser().parse(FixtureGetter.getFixture("correct_sig.txt"));
+		Email email = new EmailParserBuilder().build().parse(FixtureGetter.getFixture("correct_sig.txt"));
 		List<Fragment> fragments = email.getFragments();
-		
+
 		assertEquals(2, fragments.size());
-		
+
 		assertFalse(fragments.get(0).isQuoted());
 		assertFalse(fragments.get(1).isQuoted());
-		
+
 		assertFalse(fragments.get(0).isSignature());
 		assertTrue(fragments.get(1).isSignature());
-		
+
 		assertFalse(fragments.get(0).isHidden());
 		assertTrue(fragments.get(1).isSignature());
-		
+
 		Pattern pattern = Pattern.compile("^--\nrick");
 		Matcher matcher = pattern.matcher(fragments.get(1).getContent());
 		assertTrue(matcher.find());
 	}
-	
+
 	@Test
 	public void testOneIsNotOn() {
-		Email email = new EmailParser().parse(FixtureGetter.getFixture("email_one_is_not_on.txt"));
+		Email email = new EmailParserBuilder().build().parse(FixtureGetter.getFixture("email_one_is_not_on.txt"));
 		List<Fragment> fragments = email.getFragments();
-		
+
 		Pattern pattern = Pattern.compile("One outstanding question");
 		Matcher matcher = pattern.matcher(fragments.get(0).getContent());
 		assertTrue(matcher.find());
-		
+
 		pattern = Pattern.compile("On Oct 1, 2012");
 		matcher = pattern.matcher(fragments.get(1).getContent());
 		assertTrue(matcher.find());
 	}
-	
+
 	@Test
 	public void testCustomQuoteHeader() {
-		EmailParser parser = new EmailParser();
-		parser.getQuoteHeadersRegex().add("^(\\d{4}(.+)rta:)");
-		
+		EmailParser parser = new EmailParserBuilder()
+				.withQuoteHeadersRegex("^(\\d{4}(.+)rta:)")
+				.build();
+
 		Email email = parser.parse(FixtureGetter.getFixture("email_custom_quote_header.txt"));
 		assertEquals("Thank you!", email.getVisibleText());
 	}
-	
+
 	@Test
 	public void testCustomQuoteHeader2() {
-		EmailParser parser = new EmailParser();
-		parser.getQuoteHeadersRegex().add("^(From\\: .+ .+test\\@webdomain\\.com.+)");
-		
+		EmailParser parser = new EmailParserBuilder()
+				.withQuoteHeadersRegex("^(From\\: .+ .+test\\@webdomain\\.com.+)")
+				.build();
+
 		Email email = parser.parse(FixtureGetter.getFixture("email_customer_quote_header_2.txt"));
 		assertEquals("Thank you very much.", email.getVisibleText());
 	}
-	
+
 	@Test
 	public void testAbnormalQuoteHeader1() {
-		EmailParser parser = new EmailParser();
-		
+		EmailParser parser = new EmailParserBuilder().build();
+
 		Email email = parser.parse(FixtureGetter.getFixture("email_abnormal_quote_header_1.txt"));
 		assertEquals("Thank you kindly!", email.getVisibleText());
 	}
-	
+
 	@Test
 	public void testAbnormalQuoteHeader2() {
-		EmailParser parser = new EmailParser();
-		
+		EmailParser parser = new EmailParserBuilder().build();
+
 		Email email = parser.parse(FixtureGetter.getFixture("email_abnormal_quote_header_2.txt"));
 		assertEquals(
-			"Thank you very much for your email!\n" + 
-			"\n" + 
-			"em\u2014dash coming through..", 
+			"Thank you very much for your email!\n" +
+			"\n" +
+			"em\u2014dash coming through..",
 			email.getVisibleText());
 	}
-	
+
 	@Test
 	public void testAbnormalQuoteHeader3() {
-		EmailParser parser = new EmailParser();
-		
+		EmailParser parser = new EmailParserBuilder().build();
+
 		Email email = parser.parse(FixtureGetter.getFixture("email_abnormal_quote_header_3.txt"));
 		assertEquals(
-			"Hi Daniel,\n" + 
-			"\n" + 
-			"\n" + 
-			"Thank you very much for your email.\n" + 
-			"\n" + 
-			"Sincerely,\n" + 
-			"Homer Simpson\n" + 
-			"Nuclear Safety Inspector\n" + 
-			"\n" + 
-			"nuclear power plant, sector 7-G", 
+			"Hi Daniel,\n" +
+			"\n" +
+			"\n" +
+			"Thank you very much for your email.\n" +
+			"\n" +
+			"Sincerely,\n" +
+			"Homer Simpson\n" +
+			"Nuclear Safety Inspector\n" +
+			"\n" +
+			"nuclear power plant, sector 7-G",
 			email.getVisibleText()
 		);
 	}
-	
+
 	@Test
 	public void testAbnormalQuoteHeader4() {
-		EmailParser parser = new EmailParser();
-		
+		EmailParser parser = new EmailParserBuilder().build();
+
 		Email email = parser.parse(FixtureGetter.getFixture("email_abnormal_quote_header_4.txt"));
 		assertEquals(
-			"From: Homer Simpson\n" + 
-			"To: Support\n" + 
-			"\n" + 
-			"En\u2013dash coming through~\n" + 
-			"\n" + 
-			"Thank you very much for your email!", 
+			"From: Homer Simpson\n" +
+			"To: Support\n" +
+			"\n" +
+			"En\u2013dash coming through~\n" +
+			"\n" +
+			"Thank you very much for your email!",
 			email.getVisibleText()
 		);
 	}
-	
+
 	@Test
 	public void testAbnormalQuoteHeader5() {
-		EmailParser parser = new EmailParser();
-		
+		EmailParser parser = new EmailParserBuilder().build();
+
 		Email email = parser.parse(FixtureGetter.getFixture("email_abnormal_quote_header_5.txt"));
 		assertEquals(
-			"Hello from outlook.com!", 
+			"Hello from outlook.com!",
 			email.getVisibleText()
 		);
 	}
 
 	@Test
 	public void testAbnormalQuoteHeaderLong() {
-		EmailParser parser = new EmailParser();
-		
+		EmailParser parser = new EmailParserBuilder().build();
+
 		Email email = parser.parse(FixtureGetter.getFixture("email_abnormal_quote_header_long.txt"));
 		assertEquals(
 			"*Caution* This is a really long email.",
 			email.getVisibleText()
 		);
 	}
-	
+
 	@Test
 	public void testEmDashSignature() {
-		EmailParser parser = new EmailParser();
-		
+		EmailParser parser = new EmailParserBuilder().build();
+
 		Email email = parser.parse(FixtureGetter.getFixture("email_em_dash.txt"));
 		assertEquals("Thank you.", email.getVisibleText());
 	}
-	
+
 	@Test
 	public void testEnDashSignature() {
-		EmailParser parser = new EmailParser();
-		
+		EmailParser parser = new EmailParserBuilder().build();
+
 		Email email = parser.parse(FixtureGetter.getFixture("email_en_dash.txt"));
 		assertEquals("Thank you.", email.getVisibleText());
 	}
 
 	@Test
 	public void testDashesBetweenWords() {
-		EmailParser parser = new EmailParser();
-		
+		EmailParser parser = new EmailParserBuilder().build();
+
 		Email email = parser.parse(FixtureGetter.getFixture("email_dashes_between_words.txt"));
 		assertEquals(
-			"The text below is not a signature!\n" + 
-			"\n" + 
+			"The text below is not a signature!\n" +
+			"\n" +
 			"Parsing works correctly with mulit--dash between the words.\n" +
 			"\n" +
-			"This__also!", 
+			"This__also!",
 			email.getVisibleText()
 		);
 	}
-	
+
 
 }

--- a/src/test/java/com/edlio/emailreplyparser/EmailReplyParserTest.java
+++ b/src/test/java/com/edlio/emailreplyparser/EmailReplyParserTest.java
@@ -1,8 +1,6 @@
 package com.edlio.emailreplyparser;
 
-import static org.junit.Assert.*;
-
-import java.io.ObjectInputStream.GetField;
+import static org.junit.Assert.assertEquals;
 
 import org.junit.Test;
 
@@ -13,13 +11,13 @@ public class EmailReplyParserTest {
 		Email email = EmailReplyParser.read(null);
 		assertEquals("", email.getVisibleText());
 	}
-	
+
 	@Test
 	public void testReadWithEmptyContent() {
 		Email email = EmailReplyParser.read("");
 		assertEquals("", email.getVisibleText());
 	}
-	
+
 	@Test
 	public void testParseReply() {
 		assertEquals("Hi,\n\nYou can list the keys for the bucket and call delete for each. "
@@ -29,44 +27,44 @@ public class EmailReplyParserTest {
 				+ "RiakBucketInfo bucketInfo = bucketResponse.getBucketInfo();\n\n        for(String key : bucketInfo.getKeys()) "
 				+ "{\n            riakClient.delete(bucket, key);\n        }\n\n\nwould do it.\n\nSee also\n\nhttp://wiki.basho.com/REST-API.html#Bucket-operations\n\nwhich says\n\n"
 				+ "\"At the moment there is no straightforward way to delete an entire\nBucket. There is, however, an open ticket for the feature. To delete all\nthe keys in a bucket, "
-				+ "you'll need to delete them all individually.\"", 
+				+ "you'll need to delete them all individually.\"",
 				EmailReplyParser.parseReply(FixtureGetter.getFixture("email_2.txt")));
 	}
 
 	@Test
 	public void testParseOutSentFromIPhone() {
-		assertEquals("Here is another email", 
+		assertEquals("Here is another email",
 				EmailReplyParser.parseReply(FixtureGetter.getFixture("email_iphone.txt")));
 	}
-	
+
 	@Test
 	public void testParseOutSentFromBlackBerry() {
-		assertEquals("Here is another email", 
+		assertEquals("Here is another email",
 				EmailReplyParser.parseReply(FixtureGetter.getFixture("email_blackberry.txt")));
 	}
-	
+
 	@Test
 	public void testDoNotParseOutSendFromInRegularSentence() {
-		assertEquals("Here is another email\n\nSent from my desk, is much easier then my mobile phone.", 
+		assertEquals("Here is another email\n\nSent from my desk, is much easier then my mobile phone.",
 				EmailReplyParser.parseReply(FixtureGetter.getFixture("email_sent_from_my_not_signature.txt")));
 	}
 
 	@Test
 	public void testParseOutJustTopForOutlookReply() {
-		assertEquals("Outlook with a reply", 
+		assertEquals("Outlook with a reply",
 				EmailReplyParser.parseReply(FixtureGetter.getFixture("email_2_1.txt")));
 	}
-	
+
 	@Test
 	public void testRetainsBullets() {
-		assertEquals("test 2 this should list second\n\nand have spaces\n\nand retain this formatting\n\n\n   - how about bullets\n   - and another", 
+		assertEquals("test 2 this should list second\n\nand have spaces\n\nand retain this formatting\n\n\n   - how about bullets\n   - and another",
 				EmailReplyParser.parseReply(FixtureGetter.getFixture("email_bullets.txt")));
 	}
-	
+
 	@Test
 	public void testUnquotedReply() {
-		assertEquals("This is my reply.", 
+		assertEquals("This is my reply.",
 				EmailReplyParser.parseReply(FixtureGetter.getFixture("email_unquoted_reply.txt")));
-	}	
-	
+	}
+
 }

--- a/src/test/java/com/edlio/emailreplyparser/FixtureGetter.java
+++ b/src/test/java/com/edlio/emailreplyparser/FixtureGetter.java
@@ -2,7 +2,6 @@ package com.edlio.emailreplyparser;
 
 import java.io.BufferedReader;
 import java.io.FileInputStream;
-import java.io.FileReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 
@@ -13,11 +12,11 @@ public class FixtureGetter {
 
 		String emailText = "";
 		try {
- 
+
 			String sCurrentLine;
- 
+
 			br = new BufferedReader(new InputStreamReader (new FileInputStream("src/test/fixtures/" + fileName), "UTF-8"));
- 
+
 			while ((sCurrentLine = br.readLine()) != null) {
 				emailText += sCurrentLine + "\n";
 			}
@@ -27,9 +26,10 @@ public class FixtureGetter {
 
 		} finally {
 			try {
-				if (br != null)
+				if (br != null){
 					br.close();
-			} 
+				}
+			}
 			catch (IOException ex) {
 				ex.printStackTrace();
 			}


### PR DESCRIPTION
compiledQuoteHeaderPatterns was a static variable so it was being
modified by multiple threads causing a ConcurrentModificationException
also this could result in partterns from different threads bleeding into
each other.

Also this pushed the code to Java 11